### PR TITLE
Fix and rewrite import package script and catch import errors.

### DIFF
--- a/RoConsole.py
+++ b/RoConsole.py
@@ -5,7 +5,12 @@ try:
  from adm4.main import *
 except:
  print("Installing required packages, please wait.")
- os.system("pip install adm4 colorama robloxpy glob2 requests")    # Salty-Coder :)
+ try:
+  os.system("pip install adm4 colorama robloxpy glob2 requests")    # Salty-Coder :)
+ except:
+  print("An error occured while installing required packages. Please retry.")
+  time.sleep(5)
+  exit()
  print("finished installing required packages please restart terminal.")
 
 from colorama import *

--- a/RoConsole.py
+++ b/RoConsole.py
@@ -5,7 +5,7 @@ try:
  from adm4.main import *
 except:
  print("Installing required packages, please wait.")
- os.system("pip install adm4 && pip install colorama && pip install threading && pip install robloxpy && pip install glob2 && pip install requests")
+ os.system("pip install adm4 colorama robloxpy glob2 requests")    # Salty-Coder :)
  print("finished installing required packages please restart terminal.")
 
 from colorama import *


### PR DESCRIPTION
-Removed import script for threading as it is a core Python library and causes install script to end before importing following modules.
-Rewrote module import script to be more readable.
-Catch failure importing packages and prompts the user.